### PR TITLE
waterfall charts: add sorter dimension and sorting parameters to window functions

### DIFF
--- a/waterfall_chart/README.md
+++ b/waterfall_chart/README.md
@@ -15,6 +15,9 @@ CustomChart {
     field label {
       type: 'dimension'
     }
+    field label_sorter {
+      type: 'dimension'
+    }
   }
   options {
     // INSERT OPTION DEFINITION HERE
@@ -36,8 +39,32 @@ CustomChart {
         "calculate": "datum['@{fields.label.name}']",
         "as": "label"
       },
-      {"window": [{"op": "sum", "field": "amount", "as": "sum"}]},
-      {"window": [{"op": "lead", "field": "label", "as": "lead"}]},
+      {
+        "calculate": "datum['@{fields.label_sorter.name}']",
+        "as": "label_sorter"
+      },
+      {
+        "window": [{
+          "op": "sum", 
+          "field": "amount", 
+          "as": "sum"
+         }],
+        "sort": [{
+          "field": "label_sorter", 
+          "order": "ascending"
+         }]
+      },
+      {
+        "window": [{
+          "op": "lead", 
+          "field": "label",
+          "as": "lead"
+          }],
+        "sort": [{
+          "field": "label_sorter", 
+          "order": "ascending"
+          }]
+      },
       {
         "calculate": "datum.lead === null ? datum.label : datum.lead",
         "as": "lead"
@@ -68,7 +95,7 @@ CustomChart {
       "x": {
         "field": "label",
         "type": "ordinal",
-        "sort": null,
+        "sort": {"field": "label_sorter", "order": "ascending"},
         "axis": {"labelAngle": 0, "title": "Months"}
       }
     },


### PR DESCRIPTION
This PR adds a dimension to the Holistics waterfall custom chart so that the user can specify the sort order for the waterfall bars along the x-axis.

End-users using this template can select a sorting dimension in the Holistics UI for the waterfall chart and use this dimension as their sorting variable.

Adding this sorter dimension allows us to apply custom sorting to the `lead` and `sum` window functions used in the chart template, so that the waterfall bars appear in the waterfall chart in the desired order. This corrects for the issue shared in the Vega-Lite `window` transform [docs](https://vega.github.io/vega-lite/docs/window.html#sort-field-def) screenshotted below, whereby waterfall bars do not always appear in the correct order and so do not make sense as a waterfall.

> If sort is not specified, the order is undefined: data objects are processed in the order they are observed 

![Screenshot 2024-10-25 at 16 46 41](https://github.com/user-attachments/assets/9c84ac30-c4d5-451e-8ecd-adfe3c22f4e0)
